### PR TITLE
Bugfix: Now udoing the move works properly in a human vs human game

### DIFF
--- a/src/kreversigame.cpp
+++ b/src/kreversigame.cpp
@@ -153,6 +153,12 @@ int KReversiGame::undo()
         m_changedChips.clear();
 
     Q_EMIT boardChanged();
+
+    if (movesUndone % 2 == 1) {
+        m_curPlayer = Utils::opponentColorFor(m_curPlayer);
+        m_lastPlayer = Utils::opponentColorFor(m_curPlayer);
+    }
+
     kickCurrentPlayer();
 
     return movesUndone;


### PR DESCRIPTION
This is a bugfix for a bug which changes the current player colour in a human vs human game.

Steps to reproduce:
1. Start a human vs human game
2. Make one move for black
3. Click undo
4. Try to make a move for black again -> won't work, the current player is actually white, move for white works

The fix evaluates, if an odd number of moves has been taken back and, if yes, it changes the current player (and the last player). If you follow the above steps with this bugfix, you will see that the bug is no longer there, it's black's move after the undo.